### PR TITLE
Refact BrDanfe::Logo::Config to no implement OpenStruct

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    br_danfe (0.19.0)
+    br_danfe (0.20.0)
       barby (= 0.6.9)
       br_documents (>= 0.1.3)
       i18n (>= 0.8.6)

--- a/lib/br_danfe.rb
+++ b/lib/br_danfe.rb
@@ -6,7 +6,6 @@ require 'barby/barcode/code_128'
 require 'barby/outputter/prawn_outputter'
 require 'nokogiri'
 require 'yaml'
-require 'ostruct'
 require 'i18n'
 require 'br_documents'
 

--- a/lib/br_danfe/logo_config.rb
+++ b/lib/br_danfe/logo_config.rb
@@ -1,22 +1,11 @@
 module BrDanfe
   module Logo
-    class Config < OpenStruct
-      DEFAULTOPTIONS = { logo: '', logo_dimensions: {} }.freeze
+    class Config
+      attr_accessor :logo, :logo_dimensions
 
       def initialize(new_options = {})
-        options = DEFAULTOPTIONS.merge(config_yaml_load)
-        super options.merge(new_options)
-      end
-
-      private
-
-      def file
-        File.exist?('config/br_danfe.yml') ? File.open('config/br_danfe.yml').read : ''
-      end
-
-      def config_yaml_load
-        @file_read = YAML.safe_load(file)
-        @file_read ? (@file_read['br_danfe'] || {})['options'] : {}
+        @logo = new_options[:logo] || ''
+        @logo_dimensions = new_options[:logo_dimensions] || {}
       end
     end
   end

--- a/lib/br_danfe/version.rb
+++ b/lib/br_danfe/version.rb
@@ -1,3 +1,3 @@
 module BrDanfe
-  VERSION = '0.19.0'.freeze
+  VERSION = '0.20.0'.freeze
 end

--- a/spec/br_danfe/logo_config_spec.rb
+++ b/spec/br_danfe/logo_config_spec.rb
@@ -1,21 +1,19 @@
 require 'spec_helper'
 
 describe BrDanfe::Logo::Config do
-  let(:options) { {} }
-
-  subject { described_class.new options }
+  subject { described_class.new({}) }
 
   it 'returns the default config set in the code' do
-    expect(subject.logo).to eq('')
-    expect(subject.logo_dimensions).to eq({})
+    expect(subject.logo).to eql ''
+    expect(subject.logo_dimensions).to eql({})
   end
 
   context 'when there are custom options' do
-    let(:options) { { logo: '/fake/path/file.png', logo_dimensions: { width: 50, height: 50 } } }
+    subject { described_class.new({ logo: '/fake/path/file.png', logo_dimensions: { width: 50, height: 50 } }) }
 
     it 'returns the config set in params' do
-      expect(subject.logo).to eq('/fake/path/file.png')
-      expect(subject.logo_dimensions).to eq(width: 50, height: 50)
+      expect(subject.logo).to eql '/fake/path/file.png'
+      expect(subject.logo_dimensions).to eql width: 50, height: 50
     end
   end
 end


### PR DESCRIPTION
### Warning

```
.asdf/installs/ruby/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75: warning: .asdf/installs/ruby/3.3.5/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```
