### PR TITLE
Add the matrix gem as a dependency

### DIFF
--- a/br_danfe.gemspec
+++ b/br_danfe.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'barby', '0.6.9'
   spec.add_dependency 'br_documents', '>= 0.1.3'
   spec.add_dependency 'i18n', '>= 0.8.6'
+  spec.add_dependency 'matrix', '~> 0.4.2'
   spec.add_dependency 'nokogiri', '>= 1.8'
   spec.add_dependency 'prawn', '~> 2.5.0'
   spec.add_dependency 'prawn-table', '0.2.2'


### PR DESCRIPTION
The `matrix` gem is no longer a default dependency and needs to be bundled (since Ruby 3.1) as mentioned here:
https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/

This adds the `matrix` gem to the Gempsec, to prevent the following error on any ruby version greater 3:

`bundled_gems.rb:60:in 'Kernel.require': cannot load such file -- matrix (LoadError)`