### PR TITLE
3 - Add BrDanfe::Helper.address ahead of NFC-e renderer removal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    br_danfe (2.1.0)
+    br_danfe (2.2.0)
       barby (= 0.6.9)
       br_documents (>= 0.1.3)
       i18n (>= 0.8.6)

--- a/lib/br_danfe/helper.rb
+++ b/lib/br_danfe/helper.rb
@@ -37,5 +37,9 @@ module BrDanfe
     def self.format_cep(cep)
       cep.sub(/(\d{2})(\d{3})(\d{3})/, '\\1.\\2-\\3')
     end
+
+    def self.address(ender_tag)
+      "#{ender_tag.css('xLgr').text}, #{ender_tag.css('nro').text}, #{ender_tag.css('xBairro').text}, #{ender_tag.css('xMun').text} - #{ender_tag.css('UF').text}"
+    end
   end
 end

--- a/lib/br_danfe/version.rb
+++ b/lib/br_danfe/version.rb
@@ -1,3 +1,3 @@
 module BrDanfe
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.2.0'.freeze
 end

--- a/spec/br_danfe/helper_spec.rb
+++ b/spec/br_danfe/helper_spec.rb
@@ -225,4 +225,29 @@ describe BrDanfe::Helper do
       expect(described_class.format_cep('12345678')).to eql '12.345-678'
     end
   end
+
+  describe '.address' do
+    let(:xml) do
+      xml = <<~XML
+        <enderDest>
+          <xLgr>Rua Tijucas</xLgr>
+          <nro>99</nro>
+          <xCpl>dwdwa</xCpl>
+          <xBairro>Centro</xBairro>
+          <cMun>4218004</cMun>
+          <xMun>TIJUCAS</xMun>
+          <UF>SC</UF>
+          <CEP>88200000</CEP>
+          <cPais>1058</cPais>
+          <xPais>Brasil</xPais>
+        </enderDest>
+      XML
+
+      BrDanfe::XML.new(xml)
+    end
+
+    it 'returns a formated address string' do
+      expect(described_class.address(xml)).to eql 'Rua Tijucas, 99, Centro, TIJUCAS - SC'
+    end
+  end
 end


### PR DESCRIPTION
## Contexto

Issue #279 pede a remoção do renderer Prawn de NFC-e (`DanfeLib::Nfce` + `nfce_lib/`), que ficou sem consumidor depois da unificação de NFC-e no ThermoPrinter (facil123 #23233, PRs #23279/#23319).

Só que `ThermoPrinter::Print::Nfce::Header` e `ThermoPrinter::Print::Nfce::FiscalInfo` (facil123) ainda chamam `BrDanfe::DanfeLib::NfceLib::Helper.address` diretamente — é o único ponto do universo NFC-e que sobrevive. Remover tudo de uma vez exigiria que o bump de versão no facil123 e a troca desses dois call sites acontecessem no mesmo instante que o release daqui, o que é frágil entre dois repositórios/PRs.

## O que este PR faz

Aplica o **expand** de um expand/contract: adiciona `BrDanfe::Helper.address` (implementação idêntica à de `NfceLib::Helper.address`, copiada byte a byte) sem remover nada. `NfceLib::Helper.address` continua existindo e funcionando exatamente como antes.

- `lib/br_danfe/helper.rb` — novo `BrDanfe::Helper.address`
- `spec/br_danfe/helper_spec.rb` — spec correspondente
- `lib/br_danfe/version.rb` — bump `2.1.0` → `2.2.0` (minor, não-breaking — só adiciona API pública)

## O que NÃO muda

- `DanfeLib::Nfce`, `nfce_lib/*`, `Helper.nfe?`, specs e fixtures de NFC-e — tudo intacto.
- Nenhum call site do facil123 precisa mudar para este PR ser mergeado.

## Depois deste release

Facil123 troca os dois call sites (`header.rb`, `fiscal_info.rb`) para `BrDanfe::Helper.address` e faz bump do gem para `2.2.0`, sem urgência. Só depois disso — e depois de #23279/#23319 mergeados — um PR de **contract** remove o renderer Prawn de NFC-e inteiro (incluindo `NfceLib::Helper`, já redundante nesse ponto).

## Testes

- `bundle exec rspec`: 292 examples, 0 failures
- `bundle exec rubocop`: sem ofensas

🤖 Generated with [Claude Code](https://claude.com/claude-code)