### PR TITLE
Remove qlty integration from CI

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -37,11 +37,4 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
-      - run: |
-            curl https://qlty.sh | sh
-
-      - run: |
-            bundle exec rspec
-            ~/.qlty/bin/qlty coverage publish coverage/coverage.json
-        env:
-           QLTY_COVERAGE_TOKEN: ${{secrets.QLTY_COVERAGE_TOKEN}}
+      - run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,4 @@ group :development, :test do
   gem 'rubocop-rspec', '~> 2.25.0'
   gem 'simplecov', '0.22.0'
   gem 'simplecov-html', '0.13.1'
-  gem 'simplecov-json', '0.2.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,9 +164,6 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
-    simplecov-json (0.2.3)
-      json
-      simplecov
     simplecov_json_formatter (0.1.4)
     thor (1.3.2)
     ttfunk (1.8.0)
@@ -193,7 +190,6 @@ DEPENDENCIES
   rubocop-rspec (~> 2.25.0)
   simplecov (= 0.22.0)
   simplecov-html (= 0.13.1)
-  simplecov-json (= 0.2.3)
 
 BUNDLED WITH
    2.5.5

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,5 @@
 require 'simplecov'
-require 'simplecov-json'
-
-unless ENV["NO_COVERAGE"]
-  SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::JSONFormatter
-  ])
-  SimpleCov.start
-end
+SimpleCov.start unless ENV["NO_COVERAGE"]
 
 require "bundler/setup"
 require "br_danfe"


### PR DESCRIPTION
## Resumo

- Remove os steps de instalação e publicação do qlty (`curl https://qlty.sh | sh` + `qlty coverage publish`) do job `rspec` em `.github/workflows/config.yml`.
- Reverte `spec/spec_helper.rb` para gerar cobertura só em HTML (o formatter JSON só existia para alimentar o `qlty coverage publish`).
- Remove a gem `simplecov-json`, agora sem uso.

## Por quê

O projeto `br_danfe` no Qlty Cloud está pausado, e `qlty coverage publish` trata "paused project" como erro fatal (HTTP 400), quebrando o CI mesmo com a suíte passando 100%. Confirmado ao rerodar as PRs #280 e #281: ambas com testes verdes, falhando só nesse step.

O `facil123` já tinha cortado o qlty pelo mesmo motivo (redundante com o `couve`, que já fazia o gate de cobertura + comentário na PR).

Fecha #283.

## Plano de teste

- [x] `bundle exec rspec` local: 291 examples, 0 failures
- [x] `bundle exec rubocop --display-cop-names --parallel` local: sem ofensas
- [ ] CI verde nesta PR (sem o step do qlty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)