### PR TITLE
Post coverage report as a PR comment via couve

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -1,6 +1,13 @@
 name: Tests
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [master] # push is already covered by pull_request while a PR is open
+
+permissions:
+  contents: read
+  pull-requests: write # needed to post/update the coverage comment
 
 jobs:
   linter:
@@ -31,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # full history, needed to diff against the PR's base branch
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -38,3 +47,32 @@ jobs:
           bundler-cache: true
 
       - run: bundle exec rspec
+
+      - name: Generate coverage report for the PR's changed files
+        if: github.event_name == 'pull_request'
+        run: |
+          curl -L https://github.com/asseinfo/test-reporter/releases/download/0.11.1/cc-test-reporter > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter format-coverage coverage/coverage.json -t simplecov -o coverage/codeclimate.json
+
+          gem install couve
+
+          git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD \
+            | couve coverage/codeclimate.json coverage-report.md --changed-files -
+
+      - name: Post or update the coverage comment on the PR
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          MARKER="<!-- couve-coverage -->"
+          { echo "$MARKER"; echo; cat coverage-report.md; } > full-comment.md
+
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --paginate --jq 'map(select(.body | startswith("<!-- couve-coverage -->"))) | .[0].id // empty')
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" -F body=@full-comment.md
+          else
+            gh api -X POST "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" -F body=@full-comment.md
+          fi

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -66,7 +66,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           MARKER="<!-- couve-coverage -->"
-          { echo "$MARKER"; echo; cat coverage-report.md; } > full-comment.md
+
+          if [ "$(grep -c '^|' coverage-report.md)" -le 2 ]; then
+            REPORT="Nenhum arquivo coberto por testes foi alterado nesta PR."
+          else
+            REPORT="$(cat coverage-report.md)"
+          fi
+
+          { echo "$MARKER"; echo; echo "$REPORT"; } > full-comment.md
 
           COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
             --paginate --jq 'map(select(.body | startswith("<!-- couve-coverage -->"))) | .[0].id // empty')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,13 @@
 require 'simplecov'
-SimpleCov.start unless ENV["NO_COVERAGE"]
+require 'simplecov_json_formatter'
+
+unless ENV["NO_COVERAGE"]
+  SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([
+    SimpleCov::Formatter::JSONFormatter,
+    SimpleCov::Formatter::HTMLFormatter
+  ])
+  SimpleCov.start
+end
 
 require "bundler/setup"
 require "br_danfe"


### PR DESCRIPTION
## Resumo

Segunda PR da série de migração qlty → couve (empilhada sobre #284). Adiciona um comentário automático de cobertura nas PRs, sem nenhum gate ainda (só informativo).

## O que muda

- `spec/spec_helper.rb` — volta a gerar `coverage/coverage.json`, mas com o `simplecov_json_formatter` **oficial** (já é dependência do próprio gem `simplecov`, não precisa de gem nova) — não o `simplecov-json` de terceiros que a #284 removeu. É o schema (`meta.simplecov_version` + `coverage.<arquivo>.lines`) que o `cc-test-reporter` espera; o `simplecov-json` antigo tinha outro schema, incompatível.
- `.github/workflows/config.yml`:
  - trigger ganha `pull_request:` (mantendo `push` só em `master`, pra não rodar duas vezes com a PR aberta);
  - `permissions: pull-requests: write`, necessário pra comentar na PR;
  - `fetch-depth: 0` no checkout do job `rspec`, necessário pra `git diff` contra a branch base da PR;
  - dois steps novos, só em `pull_request`: converter `coverage.json` pro formato CodeClimate via `cc-test-reporter` (binário baixado do mirror `github.com/asseinfo/test-reporter`, já que a URL original da Code Climate está fora do ar) e rodar `couve` escopado aos arquivos alterados; e postar/atualizar (via sentinela `<!-- couve-coverage -->`) um único comentário na PR, em vez de acumular um novo a cada push.

## O que NÃO muda

- Sem `--fail-on-low-coverage` — isso fica pra uma terceira PR, depois que decidirmos o que fazer com os arquivos que hoje estão abaixo de 100% (incluindo código de suporte de teste, que precisa ser excluído do gate antes de travar merge nele).

## Plano de teste

- [x] `bundle exec rspec` local: 291 examples, 0 failures, `coverage/coverage.json` no schema correto
- [x] `bundle exec rubocop --display-cop-names --parallel` local: sem ofensas
- [x] Pipeline `cc-test-reporter` → `couve` rodado localmente contra o diff real desta branch vs. master: relatório vazio (esperado — essa PR não toca nenhum arquivo Ruby coberto)
- [ ] Comentário de cobertura aparece na PR (só testável rodando de verdade no Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)