### PR TITLE
Fail the PR when its changed files aren't fully covered

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -57,8 +57,15 @@ jobs:
 
           gem install couve
 
-          git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD \
-            | couve coverage/codeclimate.json coverage-report.md --changed-files -
+          # couve still writes coverage-report.md even when it fails the gate below,
+          # so the actual `exit 1` is deferred to a later step, after the comment
+          # (which shows exactly which lines are uncovered) has had a chance to post.
+          if git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD \
+            | couve coverage/codeclimate.json coverage-report.md --changed-files - --fail-on-low-coverage; then
+            echo "COVERAGE_OK=true" >> "$GITHUB_ENV"
+          else
+            echo "COVERAGE_OK=false" >> "$GITHUB_ENV"
+          fi
 
       - name: Post or update the coverage comment on the PR
         if: github.event_name == 'pull_request'
@@ -83,3 +90,7 @@ jobs:
           else
             gh api -X POST "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" -F body=@full-comment.md
           fi
+
+      - name: Fail if the PR's changed files aren't fully covered
+        if: github.event_name == 'pull_request' && env.COVERAGE_OK == 'false'
+        run: exit 1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,11 @@ unless ENV["NO_COVERAGE"]
     SimpleCov::Formatter::JSONFormatter,
     SimpleCov::Formatter::HTMLFormatter
   ])
-  SimpleCov.start
+  SimpleCov.start do
+    # Test support code is exercised by the specs that use it, not covered
+    # on its own — the coverage gate only applies to product code.
+    add_filter '/spec/support/'
+  end
 end
 
 require "bundler/setup"


### PR DESCRIPTION
## Resumo

Terceira PR da série de migração qlty → couve (empilhada sobre #285). Liga o gate `couve --fail-on-low-coverage`: a partir desta PR, qualquer PR cujo diff toque uma linha não coberta reprova o CI, com o comentário de cobertura mostrando exatamente qual arquivo/linha.

## O que muda

- `.github/workflows/config.yml`:
  - `--fail-on-low-coverage` no `couve`, que é o que de fato liga o gate (sem ele, o couve sempre sai com 0 independente da cobertura).
  - a chamada do `couve` deixa de rodar direto — é envolvida num `if/then/else` que captura sucesso/falha em `COVERAGE_OK` via `$GITHUB_ENV`. Necessário porque um step que falha aborta na hora (o shell da Action já roda com `set -e`), o que puxaria o step de comentário junto e o dev veria um X vermelho sem saber por quê.
  - novo último step, que só faz `exit 1` quando `COVERAGE_OK == 'false'` — assim o comentário de cobertura sempre posta *antes* do job ficar vermelho.
- `spec/spec_helper.rb` — exclui `spec/support/` do SimpleCov (`add_filter '/spec/support/'`). Código de suporte de teste (matchers, helpers) é exercitado pelas specs que o usam, não coberto por si só; sem essa exclusão, `spec/support/have_same_content_of.rb` (hoje em 44%) reprovaria a próxima PR que só tocasse esse helper por motivo nenhum relacionado à mudança real. Mesmo raciocínio documentado em `docs/padroes-de-programacao/testes-automatizados/o-que-nao-cobrir.md` do facil123.

## O que NÃO muda

- Não mexe nos 5 arquivos de produto que hoje têm gaps reais de cobertura (`document.rb` ×3 com fallback de `method_missing`/`respond_to_missing?`, `nfce_lib/header.rb` com uma branch real de layout, e `lib/prawn/font_metric_cache.rb`, um monkey-patch interno do Prawn). Backfill dessas specs é escopo de uma quarta PR, separada.
- Esta PR passa no próprio gate porque só toca `config.yml` e `spec_helper.rb`, nenhum dos dois rastreado por cobertura — confirmado localmente simulando o diff desta PR contra o coverage.json real.
- Não configura branch protection no GitHub — hoje `master` não tem nenhuma regra de proteção (`protected: false`), então um check vermelho não impede tecnicamente o merge, só sinaliza. Configurar isso é uma decisão separada, fora do escopo desta PR.

## Plano de teste

- [x] `bundle exec rspec` local: suíte verde, `spec/support/` confirmado fora do `coverage.json`
- [x] `bundle exec rubocop --display-cop-names --parallel` local: sem ofensas
- [x] Simulado localmente: diff desta PR (`config.yml` + `spec_helper.rb`) rodado através de `cc-test-reporter` + `couve --fail-on-low-coverage` → passa limpo (nenhum arquivo coberto alterado)
- [x] Simulado localmente com um arquivo novo e não coberto: `couve --fail-on-low-coverage` reprova corretamente (`couve: coverage below 100% in ...`), e o relatório continua sendo escrito mesmo com a falha
- [ ] CI verde nesta PR (rodando de verdade no Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)