### PR TITLE
Report coverage on PRs with octocov

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -34,8 +34,8 @@ jobs:
 
     permissions:
       contents: read
-      pull-requests: write # octocov posts the coverage comment
-      actions: read # octocov reads the baseline report from the artifact datastore
+      pull-requests: write
+      actions: read
 
     steps:
       - uses: actions/checkout@v3
@@ -52,6 +52,5 @@ jobs:
           name: coverage-html
           path: coverage/
 
-      # Forks get a read-only GITHUB_TOKEN, so octocov could not post its comment there
       - uses: k1LoW/octocov-action@v1
         if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -1,6 +1,9 @@
 name: Tests
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   linter:
@@ -29,6 +32,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      pull-requests: write # octocov posts the coverage comment
+      actions: read # octocov reads the baseline report from the artifact datastore
+
     steps:
       - uses: actions/checkout@v3
 
@@ -38,3 +46,12 @@ jobs:
           bundler-cache: true
 
       - run: bundle exec rspec
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: coverage/
+
+      # Forks get a read-only GITHUB_TOKEN, so octocov could not post its comment there
+      - uses: k1LoW/octocov-action@v1
+        if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,0 +1,18 @@
+coverage:
+  paths:
+    - coverage/.resultset.json
+
+comment:
+  if: is_pull_request
+
+summary:
+  if: is_pull_request
+
+report:
+  if: is_default_branch
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+
+diff:
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}


### PR DESCRIPTION
Follow-up to #284, which removed the broken qlty integration. This PR adds the coverage reporting that qlty used to provide, using [octocov](https://github.com/k1LoW/octocov) on top of the SimpleCov setup the project already has. It is an alternative to the couve-based flow proposed in #285/#286.

## What it does

- **On pull requests**: octocov posts a single, auto-updated comment with the **project total coverage and the delta vs `master`**, plus a per-file breakdown of the files in the PR scope. The full SimpleCov HTML report (with uncovered lines, file by file) is uploaded as the `coverage-html` artifact of the run.
- **On pushes to `master`**: octocov stores the coverage report as a workflow artifact (`artifact://` datastore), which becomes the baseline that future PRs are compared against.

## How

- `.octocov.yml`: octocov reads SimpleCov's `coverage/.resultset.json` natively — no format conversion, no `cc-test-reporter` binary, no external service. Baseline storage and comparison use GitHub Actions artifacts with the built-in `GITHUB_TOKEN` (no secrets).
- Workflow triggers changed from `push` on every branch to `pull_request` + `push` on `master` — octocov needs the PR context to comment, and the `master` runs to record the baseline (same trigger change as #285).
- Job permissions are scoped to the `rspec` job: `pull-requests: write` (comment) and `actions: read` (baseline artifact).
- The octocov step is skipped on PRs from forks, which get a read-only `GITHUB_TOKEN` and could not post the comment. Dependabot PRs are fine: the explicit `permissions` key is honored for them.

## Notes

- **The comment on this very PR will show no delta**: the baseline only starts existing after this lands on `master` and the workflow runs there once. From the next PR on, the comment shows `master X% → PR Y% (+/-)`.
- No coverage gate in this PR. When we want one, it is one line in `.octocov.yml` (e.g. `coverage.acceptable: current >= prev`), evaluated against the recorded baseline.

## Tested

- Full suite locally: 291 examples, 0 failures; SimpleCov line coverage 99.5% (3598/3616).
- octocov v0.75.12 ran locally against the generated `.resultset.json` with this exact config: parsed it natively and reported 99.5%, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
