### PR TITLE
Backfill coverage gaps and exclude non-product files from coverage

### DIFF
--- a/lib/br_danfe/danfe_lib/nfce_lib/header.rb
+++ b/lib/br_danfe/danfe_lib/nfce_lib/header.rb
@@ -39,10 +39,6 @@ module BrDanfe
           @logo.present? ? 2.2.cm : 0
         end
 
-        def width_box
-          @logo.present? ? 4.5.cm : 6.7.cm
-        end
-
         def cnpj(info)
           cnpj = BrDocuments::CnpjCpf::Cnpj.new info
           "CNPJ: #{cnpj.valid? ? cnpj.formatted : ''}"

--- a/spec/br_danfe/cce_lib/document_spec.rb
+++ b/spec/br_danfe/cce_lib/document_spec.rb
@@ -112,4 +112,16 @@ describe BrDanfe::CceLib::Document do
       end
     end
   end
+
+  describe 'delegating unknown methods to the underlying Prawn document' do
+    context 'when the underlying document also does not know the method' do
+      it 'raises NoMethodError' do
+        expect { subject.this_method_does_not_exist }.to raise_error(NoMethodError)
+      end
+
+      it 'does not respond to it' do
+        expect(subject.respond_to?(:this_method_does_not_exist)).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/br_danfe/danfe_lib/nfce_lib/document_spec.rb
+++ b/spec/br_danfe/danfe_lib/nfce_lib/document_spec.rb
@@ -16,4 +16,16 @@ describe BrDanfe::DanfeLib::NfceLib::ProductList do
 
     expect("#{base_dir}document#render.pdf").to have_same_content_of file: output_pdf
   end
+
+  describe 'delegating unknown methods to the underlying Prawn document' do
+    context 'when the underlying document also does not know the method' do
+      it 'raises NoMethodError' do
+        expect { subject.this_method_does_not_exist }.to raise_error(NoMethodError)
+      end
+
+      it 'does not respond to it' do
+        expect(subject.respond_to?(:this_method_does_not_exist)).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/br_danfe/danfe_lib/nfe_lib/document_spec.rb
+++ b/spec/br_danfe/danfe_lib/nfe_lib/document_spec.rb
@@ -194,4 +194,16 @@ describe BrDanfe::DanfeLib::NfeLib::Document do
       end
     end
   end
+
+  describe 'delegating unknown methods to the underlying Prawn document' do
+    context 'when the underlying document also does not know the method' do
+      it 'raises NoMethodError' do
+        expect { subject.this_method_does_not_exist }.to raise_error(NoMethodError)
+      end
+
+      it 'does not respond to it' do
+        expect(subject.respond_to?(:this_method_does_not_exist)).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,13 @@
 require 'simplecov'
-SimpleCov.start unless ENV["NO_COVERAGE"]
+
+unless ENV["NO_COVERAGE"]
+  SimpleCov.start do
+    add_filter '/spec/support/'
+
+    # Prawn internals monkey-patch, not br_danfe's own logic.
+    add_filter '/lib/prawn/'
+  end
+end
 
 require "bundler/setup"
 require "br_danfe"


### PR DESCRIPTION
Supersedes #288, rebuilt on top of current master (post-octocov, #289). The content is @pnzrfst's work, cherry-picked as a single clean commit with his authorship — the original branch carried the couve commits from #285/#286, which were closed in favor of #289.

## What it does

- Removes `width_box` from `nfce_lib/header.rb` — dead code since #159 (2021), never called.
- Adds specs for the `method_missing`/`respond_to_missing?` delegation in the three `Document` classes (cce_lib, danfe_lib/nfe_lib, danfe_lib/nfce_lib). Each was mutation-tested manually in #288.
- Excludes non-product files from coverage: `/lib/prawn/` (Prawn internals monkey-patch, from #288) and `/spec/support/` (rescued from #286, orphaned when it was closed).

## Result

Line coverage goes from 99.5% to **100.0% (3595/3595)** — verified locally with the full suite green.

The octocov comment on this PR is also the first real demonstration of the delta against the master baseline recorded since #289 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
